### PR TITLE
Namespace event to avoid collisions (e.g. create)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,14 @@ Then create a new controller:
 class GithubWebhooksController < ActionController::Base
   include GithubWebhook::Processor
 
-  def push(payload)
+  # Handle push event
+  def github_push(payload)
     # TODO: handle push webhook
+  end
+
+  # Handle create event
+  def github_create(payload)
+    # TODO: handle create webhook
   end
 
   def webhook_secret(payload)
@@ -46,7 +52,11 @@ end
 ```
 
 Add as many instance methods as events you want to handle in
-your controller. You can read the [full list of events](https://developer.github.com/v3/activity/events/types/) GitHub can notify you about.
+your controller.
+
+All events are prefixed with `github_`. So, a `push` event can be handled by `github_push(payload)`, or a `create` event can be handled by `github_create(payload)`, etc.
+
+You can read the [full list of events](https://developer.github.com/v3/activity/events/types/) GitHub can notify you about.
 
 ## Adding the Webhook to your git repository:
 

--- a/lib/github_webhook/processor.rb
+++ b/lib/github_webhook/processor.rb
@@ -51,6 +51,6 @@ module GithubWebhook::Processor
   end
 
   def event
-    @event ||= request.headers['X-GitHub-Event'].to_sym
+    @event ||= "github_#{request.headers['X-GitHub-Event']}".to_sym
   end
 end

--- a/spec/github_webhook/processor_spec.rb
+++ b/spec/github_webhook/processor_spec.rb
@@ -23,7 +23,7 @@ module GithubWebhook
 
       include GithubWebhook::Processor
 
-      def push(payload)
+      def github_push(payload)
         @pushed = payload[:foo]
       end
     end


### PR DESCRIPTION
One of the events GitHub can send through webhooks is `create` - [docs](https://developer.github.com/v3/activity/events/types/#createevent)

Since `create` is already defined and needed in [`processor.rb`](https://github.com/ssaunier/github_webhook/blob/master/lib/github_webhook/processor.rb#L11), there's no way to capture the `create` event because you would need to define `create(payload)` in your controller and that definition would override the `create` definition in `processor.rb`

My proposed solution is to require a user to prefix the method definitions in their controller with `github_`. e.g.:
- `push(payload)` would become `github_push(payload)`
- `create(payload)` would become `github_create(payload)`