### PR TITLE
Update deprecated before_filter callbacks to before_action

### DIFF
--- a/lib/github_webhook/processor.rb
+++ b/lib/github_webhook/processor.rb
@@ -2,8 +2,8 @@ module GithubWebhook::Processor
   extend ActiveSupport::Concern
 
   included do
-    before_filter :authenticate_github_request!, only: :create
-    before_filter :check_github_event!, only: :create
+    before_action :authenticate_github_request!, only: :create
+    before_action :check_github_event!, only: :create
   end
 
   class SignatureError < StandardError; end

--- a/spec/github_webhook/processor_spec.rb
+++ b/spec/github_webhook/processor_spec.rb
@@ -16,8 +16,8 @@ module GithubWebhook
       ### Helpers to mock ActionController::Base behavior
       attr_accessor :request, :pushed
 
-      def self.skip_before_filter(*args); end
-      def self.before_filter(*args); end
+      def self.skip_before_action(*args); end
+      def self.before_action(*args); end
       def head(*args); end
       ###
 
@@ -54,7 +54,7 @@ module GithubWebhook
         controller.request.headers['X-Hub-Signature'] = "sha1=52b582138706ac0c597c315cfc1a1bf177408a4d"
         controller.request.headers['X-GitHub-Event'] = 'push'
         controller.request.headers['Content-Type'] = 'application/json'
-        controller.send :authenticate_github_request!  # Manually as we don't have the before_filter logic in our Mock object
+        controller.send :authenticate_github_request!  # Manually as we don't have the before_action logic in our Mock object
         controller.create
         expect(controller.pushed).to eq "bar"
       end
@@ -65,7 +65,7 @@ module GithubWebhook
         controller.request.headers['X-Hub-Signature'] = "sha1=6986874ecdf710b04de7ef5a040161d41687407a"
         controller.request.headers['X-GitHub-Event'] = 'push'
         controller.request.headers['Content-Type'] = 'application/x-www-form-urlencoded'
-        controller.send :authenticate_github_request!  # Manually as we don't have the before_filter logic in our Mock object
+        controller.send :authenticate_github_request!  # Manually as we don't have the before_action logic in our Mock object
         controller.create
         expect(controller.pushed).to eq "bar"
       end


### PR DESCRIPTION
This pull request updates the deprecated `before_filter` actions to use the newer `before_action` syntax. This removes the deprecation warnings that are logged in Rails 5.0 projects. Since this syntax is supported in Rails 4.0 and above, it should not change any current behavior.