### PR TITLE
update events for marketplace apps

### DIFF
--- a/lib/github_webhook/processor.rb
+++ b/lib/github_webhook/processor.rb
@@ -20,7 +20,45 @@ module GithubWebhook::Processor
   #     }
   #   });
   #   console.log(events);
-  GITHUB_EVENTS_WHITELIST = %w(ping commit_comment create delete deployment deployment_status download follow fork fork_apply gist gollum issue_comment issues label member membership milestone organization org_block page_build project_card project_column project public pull_request pull_request_review pull_request_review_comment push release repository status team team_add watch integration_installation integration_installation_repositories)
+  GITHUB_EVENTS_WHITELIST = %w(
+    commit_comment
+    create
+    delete
+    deployment
+    deployment_status
+    download
+    follow
+    fork
+    fork_apply
+    gist
+    gollum
+    integration_installation
+    integration_installation_repositories
+    issues
+    issue_comment
+    label
+    member
+    membership
+    milestone
+    organization
+    org_block
+    page_build
+    ping
+    project
+    project_card
+    project_column
+    public
+    pull_request
+    pull_request_review
+    pull_request_review_comment
+    push
+    release
+    repository
+    status
+    team
+    team_add
+    watch
+  )
 
   def create
     if self.respond_to? event_method

--- a/lib/github_webhook/processor.rb
+++ b/lib/github_webhook/processor.rb
@@ -34,6 +34,8 @@ module GithubWebhook::Processor
     gollum
     installation
     installation_repositories
+    integration_installation
+    integration_installation_repositories
     issues
     issue_comment
     label

--- a/lib/github_webhook/processor.rb
+++ b/lib/github_webhook/processor.rb
@@ -32,11 +32,12 @@ module GithubWebhook::Processor
     fork_apply
     gist
     gollum
-    integration_installation
-    integration_installation_repositories
+    installation
+    installation_repositories
     issues
     issue_comment
     label
+    marketplace_purchase
     member
     membership
     milestone


### PR DESCRIPTION
GitHub has taken "GitHub Apps" and "GitHub Marketplace" out of preview, and now offers the `installation`, `installation_repositories`, and `marketplace_purchase` webhooks officially.