### PR TITLE
Fix failure when controller methods are private

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ class GithubWebhooksController < ActionController::Base
     # TODO: handle create webhook
   end
 
+  private
+
   def webhook_secret(payload)
     ENV['GITHUB_WEBHOOK_SECRET']
   end

--- a/lib/github_webhook/processor.rb
+++ b/lib/github_webhook/processor.rb
@@ -64,7 +64,7 @@ module GithubWebhook::Processor
   )
 
   def create
-    if self.respond_to? event_method
+    if self.respond_to?(event_method, true)
       self.send event_method, json_body
       head(:ok)
     else
@@ -81,7 +81,7 @@ module GithubWebhook::Processor
   HMAC_DIGEST = OpenSSL::Digest.new('sha1')
 
   def authenticate_github_request!
-    raise UnspecifiedWebhookSecretError.new unless respond_to?(:webhook_secret)
+    raise UnspecifiedWebhookSecretError.new unless respond_to?(:webhook_secret, true)
     secret = webhook_secret(json_body)
 
     expected_signature = "sha1=#{OpenSSL::HMAC.hexdigest(HMAC_DIGEST, secret, request_body)}"


### PR DESCRIPTION
The `webhook_secret` method should be private, but the calls to `respond_to?` did not include the second parameter which would look for a private method. This fixes it and updates the readme to give a private method in the example.