### PR TITLE
Log to Rails log

### DIFF
--- a/lib/github_webhook/processor.rb
+++ b/lib/github_webhook/processor.rb
@@ -22,7 +22,8 @@ module GithubWebhook::Processor
   end
 
   def github_ping(payload)
-    puts "[GithubWebhook::Processor] Hook ping received, hook_id: #{payload[:hook_id]}, #{payload[:zen]}"
+    Rails.logger.info "[GithubWebhook::Processor] Hook ping received, hook_id: "\
+      "#{payload[:hook_id]}, #{payload[:zen]}"
   end
 
   private


### PR DESCRIPTION
Instead of using `puts`, log the ping message to the Rails logger.
