### PR TITLE
Fix typo in error message

### DIFF
--- a/lib/github_webhook/processor.rb
+++ b/lib/github_webhook/processor.rb
@@ -117,7 +117,7 @@ module GithubWebhook::Processor
         payload = request_body
       else
         raise UnsupportedContentTypeError.new(
-          "Content-Type #{content_type} is not supported. Use 'application/x-www-form-urlencoded' or 'application.json")
+          "Content-Type #{content_type} is not supported. Use 'application/x-www-form-urlencoded' or 'application/json")
       end
       ActiveSupport::HashWithIndifferentAccess.new(JSON.load(payload))
     )


### PR DESCRIPTION
The correct content type is `application/json` as per https://github.com/looneym/github_webhook/blob/ad93587aec84ad0ca57ad1d80ef4fb7856906f2a/lib/github_webhook/processor.rb#L116