### PR TITLE
Re-add deprecated integration events

### DIFF
--- a/lib/github_webhook/processor.rb
+++ b/lib/github_webhook/processor.rb
@@ -31,6 +31,8 @@ module GithubWebhook::Processor
     gollum
     installation
     installation_repositories
+    integration_installation
+    integration_installation_repositories
     issue_comment
     issues
     label


### PR DESCRIPTION
GitHub have not stuck to their schedule in removing these events and are still sending them.

These are causing 500 errors on my app in production.

If this is a bit too much of a hack, maybe a separate array of deprecated events could be created raising a different exception that I can ignore in app?