### PR TITLE
Changed signing secret hash comparison to use secure_compare

### DIFF
--- a/lib/github_webhook/processor.rb
+++ b/lib/github_webhook/processor.rb
@@ -82,7 +82,7 @@ module GithubWebhook::Processor
     secret = webhook_secret(json_body)
 
     expected_signature = "sha1=#{OpenSSL::HMAC.hexdigest(HMAC_DIGEST, secret, request_body)}"
-    if signature_header != expected_signature
+    unless ActiveSupport::SecurityUtils.secure_compare(signature_header, expected_signature)
       GithubWebhook.logger && GithubWebhook.logger.warn("[GithubWebhook::Processor] signature "\
         "invalid, actual: #{signature_header}, expected: #{expected_signature}")
       raise SignatureError


### PR DESCRIPTION
Per [GitHub's webhook documentation](https://developer.github.com/webhooks/securing/) and general good practice, it is not advised to compare hashes using simple string comparison, which is vulnerable to certain timing attacks.

This PR simply changes the comparison to use the ``secure_compare`` method from ``ActiveSupport::SecurityUtils``.