### PR TITLE
Improve error message when X-Hub-Signature header is missing

### DIFF
--- a/lib/github_webhook/processor.rb
+++ b/lib/github_webhook/processor.rb
@@ -131,7 +131,7 @@ module GithubWebhook::Processor
   end
 
   def signature_header
-    @signature_header ||= request.headers['X-Hub-Signature']
+    @signature_header ||= request.headers['X-Hub-Signature'] || ''
   end
 
   def event_method

--- a/spec/github_webhook/processor_spec.rb
+++ b/spec/github_webhook/processor_spec.rb
@@ -121,6 +121,13 @@ module GithubWebhook
         controller.request.headers['Content-Type'] = 'application/xml'
         expect { controller.send :authenticate_github_request! }.to raise_error(Processor::UnsupportedContentTypeError)
       end
+
+      it 'raises SignatureError when the X-Hub-Signature header is missing' do
+        controller.request.body = StringIO.new('{}')
+        controller.request.headers['Content-Type'] = 'application/json'
+        controller.request.headers['X-GitHub-Event'] = 'ping'
+        expect { controller.send :authenticate_github_request! }.to raise_error(Processor::SignatureError)
+      end
     end
   end
 end


### PR DESCRIPTION
Improvement over the previous error message of:

    NoMethodError (undefined method `bytesize' for nil:NilClass):

    activesupport (6.1.4.1) lib/active_support/security_utils.rb:34:in `secure_compare'
    github_webhook (1.2.0) lib/github_webhook/processor.rb:96:in `authenticate_github_request!'

This was discovered when doing some manual testing with curl.