### PR TITLE
Adds pull_request_review_thread envent handling

### DIFF
--- a/lib/github_webhook/processor.rb
+++ b/lib/github_webhook/processor.rb
@@ -48,6 +48,7 @@ module GithubWebhook::Processor
     pull_request
     pull_request_review
     pull_request_review_comment
+    pull_request_review_thread
     push
     release
     repository_dispatch


### PR DESCRIPTION
Manages Github activity related to a comment thread on a pull request being marked as resolved or unresolved
The type of activity is specified in the action property of the payload object