### PR TITLE
Use ActionController::API in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then create a new controller:
 
 ```ruby
 # app/controllers/github_webhooks_controller.rb
-class GithubWebhooksController < ActionController::Base
+class GithubWebhooksController < ActionController::API
   include GithubWebhook::Processor
 
   # Handle push event


### PR DESCRIPTION
Thanks for the great work!
After updating to Rails 6, the webhook requests resulted in an ActionController::InvalidAuthenticityToken error. Using an API controller fixes it.